### PR TITLE
added some more cache-checking

### DIFF
--- a/lib/core.php
+++ b/lib/core.php
@@ -26,9 +26,22 @@ class PackagesManager {
     $this->panel  = $panel;
     $this->kirby  = $this->panel->kirby();
     $this->root   = __DIR__ . DS . '..';
-    $this->cache  = cache::setup('file', array(
-      'root' => $this->root . DS . 'cache')
-    );
+
+    // check if cache can be written, otherwise the widget will fail here,
+    // no other widget would be loaded.
+    if(c::get('packages.cache', true)) {
+        if(dir::writable($this->root . DS . 'cache')) {
+            $this->cache  = cache::setup('file', array(
+              'root' => $this->root . DS . 'cache')
+            );
+        } else {
+            // Disable caching if dir is not writable, to make sure it
+            // will continue to work
+            c::set('packages.cache', false);
+            echo 'Error: Could not create Cache-Directory: ' . $this->root . DS . 'cache';
+            return false;
+        }
+    }
   }
 
   public function html() {

--- a/lib/update.php
+++ b/lib/update.php
@@ -58,7 +58,10 @@ class Update {
       $value = $json ? $json : array();
       $alive = c::get('packages.cache.age', 60 * 24) + rand(0, 15);
 
-      $this->cache->set($key, $value, $alive);
+      if(c::get('packages.cache', true)) {
+          $this->cache->set($key, $value, $alive);
+      }
+
       return isset($value['version']) ? $value['version'] : null;
     } else {
       return null;


### PR DESCRIPTION
I added some more checking for the cache.
The cache directory couldn't be created when running local. The package-manager will then fetch just show a message, that the directory does not exists and stops. No other widget will then be loaded.

I now check if caching is enabled on init and set it to false if it's not able to create the directory.